### PR TITLE
Style Form Partial for Posts

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,9 +1,9 @@
-<%= form_with(model: post) do |form| %>
+<%= form_with(model: post, class: "space-y-6") do |form| %>
   <% if post.errors.any? %>
-    <div style="color: red">
-      <h2><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative">
+      <h2 class="font-bold"><%= pluralize(post.errors.count, "error") %> prohibited this post from being saved:</h2>
 
-      <ul>
+      <ul class="list-disc pl-5">
         <% post.errors.each do |error| %>
           <li><%= error.full_message %></li>
         <% end %>
@@ -11,7 +11,7 @@
     </div>
   <% end %>
 
-  <div>
-    <%= form.submit %>
+  <div class="mt-4">
+    <%= form.submit class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded" %>
   </div>
 <% end %>


### PR DESCRIPTION
This PR adds styles to the form partial for posts using Tailwind CSS. The changes include:

- Styling the error messages with a red background and border for better visibility.
- Adding spacing between form elements for a cleaner layout.
- Styling the submit button with a blue background and hover effect for better user interaction.

These changes enhance the visual appeal and usability of the form.