### PR TITLE
Add input fields for title and description in posts

### DIFF
--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -12,6 +12,16 @@
   <% end %>
 
   <div class="mt-4">
+    <%= form.label :title, "Title", class: "block text-gray-700 text-sm font-bold mb-2" %>
+    <%= form.text_field :title, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+  </div>
+
+  <div class="mt-4">
+    <%= form.label :description, "Description", class: "block text-gray-700 text-sm font-bold mb-2" %>
+    <%= form.text_area :description, class: "shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline" %>
+  </div>
+
+  <div class="mt-4">
     <%= form.submit class: "bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded hover:bg-blue-600" %>
   </div>
 <% end %>


### PR DESCRIPTION
This PR adds input fields for title and description in the posts form. The changes include:
- Adding a text field for the title with appropriate styling.
- Adding a text area for the description with appropriate styling.
- Ensuring the form layout is consistent and user-friendly using Tailwind CSS.