### PR TITLE
Add font-family to body using Tailwind CSS

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -23,7 +23,7 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
   </head>
 
-  <body>
+  <body class="font-sans">
     <main class="container mx-auto mt-28 px-5 flex">
       <%= yield %>
     </main>


### PR DESCRIPTION
This pull request adds the Tailwind CSS font-family utility to the <body> tag in the application.html.erb file. This change ensures that the font-family is applied globally across the application, providing a consistent look and feel.