### PR TITLE
Permit title and description in PostsController

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -60,11 +60,11 @@ class PostsController < ApplicationController
   private
     # Use callbacks to share common setup or constraints between actions.
     def set_post
-      @post = Post.find(params.expect(:id))
+      @post = Post.find(params[:id])
     end
 
     # Only allow a list of trusted parameters through.
     def post_params
-      params.fetch(:post, {})
+      params.require(:post).permit(:title, :description)
     end
 end


### PR DESCRIPTION
This pull request includes the following changes:

- Modified `posts_controller.rb` to permit `title` and `description` in the `post_params` method.
- Ensured that the `set_post` method correctly retrieves the post using `params[:id]`.

These changes allow the `title` and `description` attributes to be safely passed through the controller, enhancing the functionality of the posts management.