### PR TITLE
Remove likes from permitted params in PostsController

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -65,6 +65,6 @@ class PostsController < ApplicationController
 
     # Only allow a list of trusted parameters through.
     def post_params
-      params.require(:post).permit(:title, :description, :likes)
+      params.require(:post).permit(:title, :description)
     end
 end


### PR DESCRIPTION
This PR removes the 'likes' attribute from the permitted parameters in the PostsController. This change ensures that the 'likes' attribute is no longer accepted through mass assignment, enhancing the security and integrity of the application.