### PR TITLE
Remove 'Read More' Link from Posts

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,5 +1,4 @@
 <div id="<%= dom_id post %>">
   <h2 class="text-xl font-bold"><%= post.title %></h2>
   <p class="mt-2 text-gray-600"><%= post.description %></p>
-  <a href="#" class="text-blue-500 hover:text-blue-700 transition duration-300 ease-in-out transform hover:scale-110">Read More</a>
 </div>


### PR DESCRIPTION
This pull request removes the 'Read More' link from the posts partial view. The link was deemed unnecessary and has been removed to simplify the UI. The change affects the `_post.html.erb` file, ensuring a cleaner presentation of post titles and descriptions without the additional link.