### PR TITLE
Change 'Back to posts' link color to orange

### DIFF
--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -7,5 +7,5 @@
 <br>
 
 <div>
-  <%= link_to "Back to posts", posts_path, class: "hover:text-blue-600" %>
+  <%= link_to "Back to posts", posts_path, class: "hover:text-orange-600" %>
 </div>


### PR DESCRIPTION
This PR changes the color of the 'Back to posts' link to orange in the new post view. The change is made to enhance the visual appeal and consistency with the new design guidelines.