### PR TITLE
Change 'New post' button color to red

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -27,6 +27,6 @@
 
 
   <div class="mt-4">
-    <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600 transition duration-300 ease-in-out transform hover:scale-110" %>
+    <%= link_to "New post", new_post_path, class: "bg-red-500 text-white py-2 px-4 rounded hover:bg-red-600 transition duration-300 ease-in-out transform hover:scale-110" %>
   </div>
 </div>


### PR DESCRIPTION
This PR changes the color of the 'New post' button in the posts index view from orange to red for better visibility and consistency with the design theme.