### PR TITLE
Remove Transition Effects from New Post Button

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -20,6 +20,6 @@
     <% end %>
   </div>
   <div class="mt-4 flex justify-center">
-    <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>
+    <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded" %>
   </div>
 </div>


### PR DESCRIPTION
This pull request removes the transition effects from the 'New post' button on the posts page. The changes were made to improve the user experience by eliminating unnecessary animations.