### PR TITLE
Add Transitions to SHOW THIS POST Button/Link

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,7 +14,7 @@
       <div class="p-4 bg-white shadow rounded border border-gray-200">
         <%= render post %>
         <p class="mt-2">
-          <%= link_to "SHOW THIS POST", post, class: "bg-red-300 text-white py-2 px-4 rounded hover:bg-red-400" %>
+          <%= link_to "SHOW THIS POST", post, class: "bg-red-300 text-white py-2 px-4 rounded hover:bg-red-400 transition duration-300 ease-in-out transform hover:scale-110" %>
         </p>
       </div>
     <% end %>


### PR DESCRIPTION
This pull request adds transitions to the "SHOW THIS POST" button/link on the posts page. The changes include:
- Adding a transition effect to the button/link for a smoother user experience.
- Utilizing Tailwind CSS for styling to maintain consistency with the existing design.

Please review the changes and provide feedback. If everything looks good, kindly approve and merge the PR.