### PR TITLE
Change Color of New Post Button/Link

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -20,6 +20,6 @@
     <% end %>
   </div>
   <div class="mt-4 flex justify-center">
-    <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>
+    <%= link_to "New post", new_post_path, class: "bg-purple-500 text-white py-2 px-4 rounded hover:bg-purple-600" %>
   </div>
 </div>


### PR DESCRIPTION
This pull request changes the color of the 'New Post' button/link on the posts page from orange to purple. The new color scheme uses Tailwind CSS classes to ensure a consistent look and feel across the application. The button now has a purple background with a hover effect that changes the shade of purple.