### PR TITLE
Change color of 'SHOW THIS POST' button to blue

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -14,7 +14,7 @@
       <div class="p-4 bg-white shadow rounded border border-gray-200">
         <%= render post %>
         <p class="mt-2">
-          <%= link_to "SHOW THIS POST", post, class: "bg-red-300 text-white py-2 px-4 rounded hover:bg-red-400 transition duration-300 ease-in-out transform hover:scale-110" %>
+          <%= link_to "SHOW THIS POST", post, class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110" %>
         </p>
       </div>
     <% end %>


### PR DESCRIPTION
This pull request changes the color of the 'SHOW THIS POST' button on the posts page from red to blue. The new color scheme uses Tailwind CSS classes to ensure a consistent look and feel across the application. The button now has a blue background with a hover effect that changes the shade of blue.