### PR TITLE
Add link to Cricbuzz in posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -29,6 +29,9 @@
   <p class="mt-2">
     <%= link_to "Codemancers", "https://www.codemancers.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
+  <p class="mt-2">
+    <%= link_to "Cricbuzz", "https://www.cricbuzz.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
+  </p>
   <div class="mt-4 flex justify-center">
     <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>
   </div>


### PR DESCRIPTION
This PR adds a link to Cricbuzz on the posts page. The link is styled similarly to the existing Google link and opens in a new tab.