### PR TITLE
Remove Google link from posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -21,9 +21,6 @@
   </div>
 
   <p class="mt-2">
-    <%= link_to "Google", "https://www.google.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
-  </p>
-  <p class="mt-2">
     <%= link_to "Codemancers", "https://www.codemancers.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
   <p class="mt-2">


### PR DESCRIPTION
This pull request removes the Google link from the posts page in the dummy-test repository. The change involves deleting the HTML block that contained the Google link, ensuring a cleaner UI without unnecessary external links.