### PR TITLE
Add W3Schools link to posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -26,6 +26,9 @@
   <p class="mt-2">
     <%= link_to "Codemancers", "https://www.codemancers.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
+  <p class="mt-2">
+    <%= link_to "W3Schools", "https://www.w3schools.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
+  </p>
   <div class="mt-4 flex justify-center">
     <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>
   </div>


### PR DESCRIPTION
This pull request adds a link to W3Schools on the posts page in the dummy-test repository. The change involves adding an HTML block that contains the W3Schools link, enhancing the UI with useful external resources.