### PR TITLE
Remove all links except Codemancers from posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -21,13 +21,7 @@
   </div>
 
   <p class="mt-2">
-    <%= link_to "Facebook", "https://www.facebook.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
-  </p>
-  <p class="mt-2">
     <%= link_to "Codemancers", "https://www.codemancers.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
-  </p>
-  <p class="mt-2">
-    <%= link_to "HackerRank", "https://www.hackerrank.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
 
   <div class="mt-4 flex justify-center">


### PR DESCRIPTION
This PR removes all external links except for the Codemancers link from the posts page. The changes were made to ensure only relevant links are displayed, improving the user experience.