### PR TITLE
Change placeholder text to 'Search posts' in posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -4,7 +4,7 @@
   <div class="mb-4">
     <%= form_with url: posts_path, method: :get, local: true do %>
       <div class="flex items-center">
-        <%= text_field_tag :query, params[:query], placeholder: "Search posts by title...", class: "border border-gray-300 rounded py-2 px-4 mr-2 w-full" %>
+        <%= text_field_tag :query, params[:query], placeholder: "Search posts", class: "border border-gray-300 rounded py-2 px-4 mr-2 w-full" %>
         <%= submit_tag "Search", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110" %>
       </div>
     <% end %>


### PR DESCRIPTION
This pull request updates the placeholder text in the search field on the posts page from 'Search posts by title...' to 'Search posts'. This change simplifies the user interface and makes the search functionality more intuitive.