### PR TITLE
Add Amazon link to posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -29,6 +29,9 @@
   <p class="mt-2">
     <%= link_to "HackerRank", "https://www.hackerrank.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
+  <p class="mt-2">
+    <%= link_to "Amazon", "https://www.amazon.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
+  </p>
 
   <div class="mt-4 flex justify-center">
     <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>


### PR DESCRIPTION
This PR adds an Amazon link to the posts page in the dummy-test repository. The link is styled consistently with existing links and opens in a new tab.