### PR TITLE
Add Zepto link to posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -32,6 +32,9 @@
   <p class="mt-2">
     <%= link_to "LeetCode", "https://leetcode.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
+  <p class="mt-2">
+    <%= link_to "Zepto", "https://www.zepto.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
+  </p>
 
   <div class="mt-4 flex justify-center">
     <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>


### PR DESCRIPTION
This pull request adds a new link to Zepto on the posts page, styled consistently with the existing links. The changes are straightforward and consistent with the existing code style. No syntax, logical, or security issues were identified.