### PR TITLE
Add Google link to posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -24,6 +24,10 @@
     <%= link_to "Codemancers", "https://www.codemancers.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
 
+  <p class="mt-2">
+    <%= link_to "Google", "https://www.google.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
+  </p>
+
   <div class="mt-4 flex justify-center">
     <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>
   </div>


### PR DESCRIPTION
### Summary

This pull request adds a new link to Google on the posts page.

### Changes Made
- Modified `app/views/posts/index.html.erb` to include a link to Google.

### Testing
- Verified that the link appears correctly on the posts page and opens Google in a new tab.

### Notes
- The link follows the existing styling pattern for external links on the page.