### PR TITLE
Add Amazon link to posts page

### DIFF
--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -28,6 +28,10 @@
     <%= link_to "Google", "https://www.google.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
   </p>
 
+  <p class="mt-2">
+    <%= link_to "Amazon", "https://www.amazon.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
+  </p>
+
   <div class="mt-4 flex justify-center">
     <%= link_to "New post", new_post_path, class: "bg-orange-500 text-white py-2 px-4 rounded hover:bg-orange-600" %>
   </div>


### PR DESCRIPTION
### Summary

This pull request adds a new link to Amazon on the posts page.

### Changes Made
- Modified the `index.html.erb` file to include a new link to Amazon.

### Diff Summary
```diff
+ <p class="mt-2">
+   <%= link_to "Amazon", "https://www.amazon.com", class: "bg-blue-500 text-white py-2 px-4 rounded hover:bg-blue-600 transition duration-300 ease-in-out transform hover:scale-110", target: "_blank" %>
+ </p>
```

### Code Review
- **Syntax & Structure:** The code follows the existing structure and syntax used for other links on the page.
- **Logical & Structural Issues:** None identified.
- **Security Concerns:** None identified.
- **Performance Optimizations:** The code is consistent with existing patterns and does not introduce any performance issues.

### Conclusion
The changes are straightforward and consistent with the existing code style. No issues were found in the review.